### PR TITLE
Add skeleton router and pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "idb": "^8.0.3",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-router-dom": "^6.23.0",
     "recharts": "^2.15.3",
     "zustand": "^5.0.5"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       react-dom:
         specifier: ^19.1.0
         version: 19.1.0(react@19.1.0)
+      react-router-dom:
+        specifier: ^6.23.0
+        version: 6.30.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       recharts:
         specifier: ^2.15.3
         version: 2.15.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -882,6 +885,10 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@remix-run/router@1.23.0':
+    resolution: {integrity: sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==}
+    engines: {node: '>=14.0.0'}
 
   '@rolldown/pluginutils@1.0.0-beta.9':
     resolution: {integrity: sha512-e9MeMtVWo186sgvFFJOPGy7/d2j2mZhLJIdVW0C/xDluuOvymEATqz6zKsP0ZmXGzQtqlyjz5sC1sYQUoJG98w==}
@@ -2484,6 +2491,19 @@ packages:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
 
+  react-router-dom@6.30.1:
+    resolution: {integrity: sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
+
+  react-router@6.30.1:
+    resolution: {integrity: sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: '>=16.8'
+
   react-smooth@4.0.4:
     resolution: {integrity: sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==}
     peerDependencies:
@@ -3984,6 +4004,8 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
+
+  '@remix-run/router@1.23.0': {}
 
   '@rolldown/pluginutils@1.0.0-beta.9': {}
 
@@ -5611,6 +5633,18 @@ snapshots:
   react-is@18.3.1: {}
 
   react-refresh@0.17.0: {}
+
+  react-router-dom@6.30.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      '@remix-run/router': 1.23.0
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      react-router: 6.30.1(react@19.1.0)
+
+  react-router@6.30.1(react@19.1.0):
+    dependencies:
+      '@remix-run/router': 1.23.0
+      react: 19.1.0
 
   react-smooth@4.0.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,23 @@
+import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom'
+import AppShell from './components/AppShell'
+import Library from './pages/Library'
+import Mix from './pages/Mix'
+import Match from './pages/Match'
+import Settings from './pages/Settings'
 
 function App() {
   return (
-    <div className="flex h-screen items-center justify-center bg-gray-100 dark:bg-gray-900">
-      <h1 className="text-3xl font-bold text-gray-800 dark:text-gray-100">
-        Hello PaintMix
-      </h1>
-    </div>
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<AppShell />}> 
+          <Route index element={<Navigate to="/library" replace />} />
+          <Route path="library" element={<Library />} />
+          <Route path="mix" element={<Mix />} />
+          <Route path="match" element={<Match />} />
+          <Route path="settings" element={<Settings />} />
+        </Route>
+      </Routes>
+    </BrowserRouter>
   )
 }
 

--- a/src/__tests__/smoke.test.tsx
+++ b/src/__tests__/smoke.test.tsx
@@ -1,0 +1,7 @@
+import { describe, it, expect } from 'vitest'
+
+describe('smoke', () => {
+  it('runs', () => {
+    expect(true).toBe(true)
+  })
+})

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1,0 +1,30 @@
+import { Link, Outlet, useLocation } from 'react-router-dom'
+
+const tabs = [
+  { path: '/library', label: 'Library' },
+  { path: '/mix', label: 'Mix' },
+  { path: '/match', label: 'Match' },
+  { path: '/settings', label: 'Settings' },
+]
+
+export default function AppShell() {
+  const location = useLocation()
+  return (
+    <div className="flex h-screen flex-col">
+      <nav className="bg-gray-200 dark:bg-gray-800 p-2 flex space-x-4 justify-center">
+        {tabs.map(tab => (
+          <Link
+            key={tab.path}
+            to={tab.path}
+            className={`px-3 py-1 rounded ${location.pathname === tab.path ? 'bg-blue-500 text-white' : 'text-gray-700 dark:text-gray-200'}`}
+          >
+            {tab.label}
+          </Link>
+        ))}
+      </nav>
+      <main className="flex-1 overflow-auto p-4 bg-gray-100 dark:bg-gray-900">
+        <Outlet />
+      </main>
+    </div>
+  )
+}

--- a/src/pages/Library.tsx
+++ b/src/pages/Library.tsx
@@ -1,0 +1,8 @@
+export default function Library() {
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">Paint Library</h1>
+      <button className="px-4 py-2 bg-blue-500 text-white rounded">+ Paint</button>
+    </div>
+  )
+}

--- a/src/pages/Match.tsx
+++ b/src/pages/Match.tsx
@@ -1,0 +1,8 @@
+export default function Match() {
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">Colour Matcher</h1>
+      <button className="px-4 py-2 bg-green-500 text-white rounded">Find</button>
+    </div>
+  )
+}

--- a/src/pages/Mix.tsx
+++ b/src/pages/Mix.tsx
@@ -1,0 +1,9 @@
+export default function Mix() {
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">Mix Calculator</h1>
+      <button className="px-4 py-2 bg-blue-500 text-white rounded">Add component</button>
+      <button className="px-4 py-2 bg-green-500 text-white rounded">Calculate</button>
+    </div>
+  )
+}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,0 +1,9 @@
+export default function Settings() {
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">Settings & Backup</h1>
+      <button className="px-4 py-2 bg-blue-500 text-white rounded">Export JSON</button>
+      <button className="px-4 py-2 bg-blue-500 text-white rounded">Import JSON</button>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- install `react-router-dom`
- create AppShell component with navigation bar
- wire `App.tsx` with React Router and routes
- scaffold page components for Library, Mix, Match and Settings
- add a minimal passing test

## Testing
- `pnpm vitest run`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68432ba4af0c8332a3588aabd74acf51